### PR TITLE
Remove console log

### DIFF
--- a/client/src/components/ideas/CreateIdea.vue
+++ b/client/src/components/ideas/CreateIdea.vue
@@ -137,9 +137,6 @@ export default {
         ideaDesc: this.ideaDesc,
         links: this.links,
       };
-
-      console.log(payload);
-      //  TODO Submit to server
     },
   },
 };


### PR DESCRIPTION
Linter doesn't like console logs, the code still runs but it can be an annoyance.