### PR TITLE
Feature/dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,19 @@ as user id's and passwords for service accounts.
 
 The `/server/.env` file must contain the following: 
 ```
+# MongoDB Authentication 
 DBUSERID=userid
 DBPASSWD=password
 ```
 
 and the `/client/.env` file must contain these environment variables:
 ```
-TBD
+# Auth0 Authentication
+CLIENTID=client-secret
+CLIENTDOMAIN=auth0-client-url
+REDIRECT=auth0-callback-url
+SCOPE=auth0-return-data
+AUDIENCE=auth0-api-url
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -85,12 +85,17 @@ defined:
 
 | Variable Name  | Description                          |
 |:---------------|:-------------------------------------|
-| DBUSERID       | The user id of the MongoDB instance containing the application data |
-| DBPASSWD       | The associated password for the database user id |
+| DBUSERID       | User id of the MongoDB instance containing the application data |
+| DBPASSWD       | Associated password for the database user id |
+| CLIENTID       | Auth0 client secret |
+| CLIENTDOMAIN   | Auth0 client URL |
+| REDIRECT       | Application callback URL |
+| SCOPE          | Data items to be returned for authenticated users |
+| AUDIENCE       | URL of the Auth0 API |
 
 This is accomplished by including the following in the `.env` files located in
-the root of the client and server directories. The `.env` files must never be
-uploaded to GitHub since they contain application sensitive information such
+the root of the server directory. The `.env` file must never be
+uploaded to GitHub since it contains application sensitive information such
 as user id's and passwords for service accounts.
 
 The `/server/.env` file must contain the following: 
@@ -98,10 +103,6 @@ The `/server/.env` file must contain the following:
 # MongoDB Authentication 
 DBUSERID=userid
 DBPASSWD=password
-```
-
-and the `/client/.env` file must contain these environment variables:
-```
 # Auth0 Authentication
 CLIENTID=client-secret
 CLIENTDOMAIN=auth0-client-url

--- a/README.md
+++ b/README.md
@@ -88,10 +88,20 @@ defined:
 | DBUSERID       | The user id of the MongoDB instance containing the application data |
 | DBPASSWD       | The associated password for the database user id |
 
-For example:
+This is accomplished by including the following in the `.env` files located in
+the root of the client and server directories. The `.env` files must never be
+uploaded to GitHub since they contain application sensitive information such
+as user id's and passwords for service accounts.
+
+The `/server/.env` file must contain the following: 
 ```
-   export DBUSERID=userid
-   export DBPASSWD=password
+DBUSERID=userid
+DBPASSWD=password
+```
+
+and the `/client/.env` file must contain these environment variables:
+```
+TBD
 ```
 
 ### Configuration

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
+    "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "express-jwt": "^5.3.0",
     "jwks-rsa": "^1.2.0",

--- a/server/services/mongoose.config.js
+++ b/server/services/mongoose.config.js
@@ -1,4 +1,6 @@
-require('dotenv').config()
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 let config = {};
 config.db = {};

--- a/server/services/mongoose.config.js
+++ b/server/services/mongoose.config.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 let config = {};
 config.db = {};
 


### PR DESCRIPTION
Added support for storing environment variables including MLAB and AUTH0 variables in a `/server/.env` file. Note that this file has been added to `.gitignore` to prevent this data from being exposed outside of the IdeaNebulae team.